### PR TITLE
Some enhancements

### DIFF
--- a/PrinceOfPersia1.4.asl
+++ b/PrinceOfPersia1.4.asl
@@ -157,7 +157,7 @@ split
     bool doSplit = ((old.Level != current.Level) && !skipSplit) ||       // if level changes
                    (current.Level == 14 && current.EndGame == 255);      // if currently on level 14 and EndGame changes to 255
 
-    if (doSplit && settings["single_level_mode"] == true) {
+    if (doSplit && settings["single_level_mode"]) {
         vars.levelChanged = true;
     }
     

--- a/PrinceOfPersia1.4.asl
+++ b/PrinceOfPersia1.4.asl
@@ -31,7 +31,6 @@ state("DOSBOX")
     byte MinutesLeft    : "DOSBox.exe", 0x193C370, 0x1E350;          // Minutes
     int  Count          : "DOSBox.exe", 0x193C370, 0x1E354;          // Frames
     short FrameSeconds  : "DOSBox.exe", 0x193C370, 0x1E356;          // Frames in second part of time (720-0)
-    byte Sound          : "DOSBox.exe", 0x193C370, 0x2F233;          // 0 if sound is on, 1 if sound is off
     byte Room           : "DOSBox.exe", 0x193C370, 0x1D107;          // shows current room ID
     byte IsRestartLevel : "DOSBox.exe", 0x193C370, 0x1E16A;          // the is_restart_level (Ctrl+A) flag 
     byte LevelTextTime  : "DOSBox.exe", 0x193C370, 0x1F35E;          // frames left for showing the "Level N" text
@@ -46,14 +45,11 @@ startup
 {
     refreshRate = 30; // Prince of Persia runs at 12 fps, let's update 2.5x as often to be sure
     
-    settings.Add("sound_settings", true, "Checking sound");
-        settings.Add("sound", false, "Sound On At Start?", "sound_settings");
-        
-    settings.Add("split_settings", true, "Additional split configuration");
+    settings.Add("split_settings", true, "Split configuration");
         settings.Add("disable_levelskip_detection", false, "Disable 'Level Skip' category detection (keep splits for levels 1-3)", "split_settings");
         settings.Add("merge_level_12", false, "Don't split between levels 12 and 13 (treat tower Level and Jaffar level as one segment)", "split_settings");
     
-    settings.Add("single_level_mode", false, "Single level mode");
+    settings.Add("single_level_mode", false, "Individual level mode");
     
     vars.isLevelSkipMode = (Func<bool>) (() => {
         string categoryName = timer.Run.GetExtendedCategoryName().ToLower();
@@ -62,31 +58,28 @@ startup
         return isLevelSkip;
     });
     
-    vars.getBaseFramesRemaining = (Func<int>) (() => {
-        return (vars.isLevelSkipMode() ? (15) : (60)) * 720; 
-    });
-    
     vars.levelRestartSafetyBuffer = 30;  // resets are suppressed for 2.5s after CTRL+A
     vars.levelRestartTimestamp = 60*720;
     vars.levelChanged = false;
     vars.levelRestarted = false;
+    vars.LevelSkipActivated = false;
 }
 
 start
 {
-    // start (sound) && if starting level = 1 AND if level = 1 AND if Minutes = 60 AND count is = 47120384
-    bool startGame = ((current.Sound == 0 && settings["sound"] == true) || (settings["sound"] == false)) &&
-                     (current.Start == 0x1) && 
+    // start if start variable = 1 AND if level = 1 AND if Minutes = 60 AND count is = 47120384
+    bool startGame = (current.Start == 0x1) && 
                      (current.Level == 0x1) && 
                      (current.MinutesLeft == 0x3C) && 
                      (current.Count >= 0x2CE0000);
 
-    bool singleLevelModeRestart = (settings["single_level_mode"] == true && vars.levelRestarted == true);
+    bool singleLevelModeRestart = (settings["single_level_mode"] && vars.levelRestarted);
     
     if (startGame) {
         vars.levelRestartTimestamp = 60*720;
         vars.levelRestarted = false;
         vars.levelChanged = false;
+        vars.LevelSkipActivated = false;
     } else if (singleLevelModeRestart) {
         vars.levelRestarted = false; 
     }
@@ -108,24 +101,25 @@ reset
     
     //print("POPASL.flags: " + current.RestartFlag0 + " " + current.RestartFlag1 + " " + current.RestartFlag2);
     
-    bool singleLevelModeRestart = (settings["single_level_mode"] == true && levelRestartInProgress == true && levelTimeJustAppeared == true);
-    bool singleLevelModeChangedLevel = (settings["single_level_mode"] == true && vars.levelChanged == true);
+    bool singleLevelModeRestart = (settings["single_level_mode"] && levelRestartInProgress && levelTimeJustAppeared);
+    bool singleLevelModeChangedLevel = (settings["single_level_mode"] && vars.levelChanged);
 
     if (notPlaying) {
         vars.levelRestartTimestamp = 60*720;
         vars.levelRestarted = false;
+        vars.LevelSkipActivated = false;
     } else if (singleLevelModeRestart || singleLevelModeChangedLevel) {
-        int minutesLeft = current.MinutesLeft - 1;
-        int totalFramesLeft = (minutesLeft * 720) + current.FrameSeconds;
-        int adjustedFramesLeft = (minutesLeft < 0) ? 0 : totalFramesLeft; //time has expired
-        
-        if ((vars.levelChanged || adjustedFramesLeft <= (vars.levelRestartTimestamp - vars.levelRestartSafetyBuffer) || (adjustedFramesLeft > vars.levelRestartTimestamp)) && !(current.Level == 3 && current.Level3CP == 1)) {
-            vars.levelRestartTimestamp = adjustedFramesLeft;
-            vars.levelRestarted = true;
-            vars.levelChanged = false;
-            singleLevelModeRestart = true;
+        if ((vars.levelChanged ||
+	        (current.Level == 1 && vars.adjustedFramesLeft <= vars.levelRestartTimestamp - vars.levelRestartSafetyBuffer) ||
+	        (current.Level != 1 && vars.adjustedFramesLeft <= vars.levelRestartTimestamp) ||
+	        (vars.adjustedFramesLeft > vars.levelRestartTimestamp)) && 
+	        !(current.Level == 3 && current.Level3CP == 1)) {
+                vars.levelRestartTimestamp = vars.adjustedFramesLeft;
+                vars.levelRestarted = true;
+                vars.levelChanged = false;
+                singleLevelModeRestart = true;
         } else {
-            singleLevelModeRestart = false;
+                singleLevelModeRestart = false;
         }
     }
 
@@ -134,36 +128,31 @@ reset
 
 gameTime
 {
-    int minutesLeft = current.MinutesLeft - 1;
-    int totalFramesLeft = (minutesLeft * 720) + current.FrameSeconds;
-    int adjustedFramesLeft = (minutesLeft < 0) ? 0 : totalFramesLeft; //time has expired
+    vars.minutesLeft = current.MinutesLeft - 1;
+    vars.totalFramesLeft = (vars.minutesLeft * 720) + current.FrameSeconds;
+    vars.adjustedFramesLeft = (vars.minutesLeft < 0) ? 0 : vars.totalFramesLeft; //time has expired
     
-    int baseFramesRemaining = vars.getBaseFramesRemaining();
-    if (settings["single_level_mode"] == true) {
-        baseFramesRemaining = vars.levelRestartTimestamp; //single level mode (use the time of restart as base time)
+    if((old.MinutesLeft != 15 && current.MinutesLeft == 15) && (old.FrameSeconds != 718 && old.FrameSeconds != 719 && current.FrameSeconds == 718)){
+        vars.LevelSkipActivated = true;
     }
-    
-    int elapsedFrames = (baseFramesRemaining) - adjustedFramesLeft;    
+    int BaseFramesRemaining = settings["single_level_mode"] ? vars.levelRestartTimestamp : ((vars.LevelSkipActivated ? (15) : (60)) * 720);
+    int elapsedFrames = BaseFramesRemaining - vars.adjustedFramesLeft;    
     double secondsElapsed = elapsedFrames / 12.0;
-    if (old.Level == 13 && current.Level == 14) {
-        secondsElapsed = secondsElapsed - 0.002;   // hack for splits.io issue - if last split is empty, gametime won't be available
-    }
+    secondsElapsed = (old.Level == 13 && current.Level == 14 && !settings["single_level_mode"]) ? (secondsElapsed - 0.002) : (secondsElapsed);   // hack for splits.io issue - if last split is empty, gametime won't be available
+    
     //print("POPASL[gameTime]: secondsElapsed = " + secondsElapsed);
     return TimeSpan.FromSeconds(secondsElapsed);
 }
 
 split
 {
-    bool suppressFirstLevels = (settings["disable_levelskip_detection"] == false && vars.isLevelSkipMode() == true);
-    bool suppressJaffarLevel = (settings["merge_level_12"] == true);
+    bool suppressFirstLevels = (!settings["disable_levelskip_detection"] && vars.isLevelSkipMode() && old.Level <= 3) ;
+    bool suppressJaffarLevel = (settings["merge_level_12"] && old.Level == 12);
     
-    bool skipFirstLevelsSplit  = suppressFirstLevels && (old.Level <= 3);
-    bool skipJaffarLevelsSplit = suppressJaffarLevel && (old.Level == 12);
-    
-    bool skipSplit = (skipFirstLevelsSplit || skipJaffarLevelsSplit);
+    bool skipSplit = (suppressFirstLevels || suppressJaffarLevel);
     
     bool doSplit = ((old.Level != current.Level) && !skipSplit) ||       // if level changes
-                   (current.Level == 0xE && current.EndGame == 0xFF);    // if currently on level 14 and EndGame changes to 255
+                   (current.Level == 14 && current.EndGame == 255);      // if currently on level 14 and EndGame changes to 255
 
     if (doSplit && settings["single_level_mode"] == true) {
         vars.levelChanged = true;

--- a/PrinceOfPersia1.4.asl
+++ b/PrinceOfPersia1.4.asl
@@ -132,9 +132,12 @@ gameTime
     vars.totalFramesLeft = (vars.minutesLeft * 720) + current.FrameSeconds;
     vars.adjustedFramesLeft = (vars.minutesLeft < 0) ? 0 : vars.totalFramesLeft; //time has expired
     
-    if((old.MinutesLeft != 15 && current.MinutesLeft == 15) && (old.FrameSeconds != 718 && old.FrameSeconds != 719 && current.FrameSeconds == 718)){
+    if((old.MinutesLeft != 15 && current.MinutesLeft == 15) && 
+       (old.FrameSeconds != 718 && old.FrameSeconds != 719 && current.FrameSeconds == 718) &&
+       !settings["single_level_mode"]){
         vars.LevelSkipActivated = true;
     }
+    
     int BaseFramesRemaining = settings["single_level_mode"] ? vars.levelRestartTimestamp : ((vars.LevelSkipActivated ? (15) : (60)) * 720);
     int elapsedFrames = BaseFramesRemaining - vars.adjustedFramesLeft;    
     double secondsElapsed = elapsedFrames / 12.0;

--- a/PrinceOfPersia1.4.asl
+++ b/PrinceOfPersia1.4.asl
@@ -31,6 +31,7 @@ state("DOSBOX")
     byte MinutesLeft    : "DOSBox.exe", 0x193C370, 0x1E350;          // Minutes
     int  Count          : "DOSBox.exe", 0x193C370, 0x1E354;          // Frames
     short FrameSeconds  : "DOSBox.exe", 0x193C370, 0x1E356;          // Frames in second part of time (720-0)
+    byte Sound          : "DOSBox.exe", 0x193C370, 0x2F233;          // 0 if sound is on, 1 if sound is off
     byte Room           : "DOSBox.exe", 0x193C370, 0x1D107;          // shows current room ID
     byte IsRestartLevel : "DOSBox.exe", 0x193C370, 0x1E16A;          // the is_restart_level (Ctrl+A) flag 
     byte LevelTextTime  : "DOSBox.exe", 0x193C370, 0x1F35E;          // frames left for showing the "Level N" text
@@ -45,6 +46,9 @@ startup
 {
     refreshRate = 30; // Prince of Persia runs at 12 fps, let's update 2.5x as often to be sure
     
+    settings.Add("sound_settings", true, "Checking sound");
+        settings.Add("sound", false, "Sound On At Start?", "sound_settings");
+	
     settings.Add("split_settings", true, "Split configuration");
         settings.Add("disable_levelskip_detection", false, "Disable 'Level Skip' category detection (keep splits for levels 1-3)", "split_settings");
         settings.Add("merge_level_12", false, "Don't split between levels 12 and 13 (treat tower Level and Jaffar level as one segment)", "split_settings");
@@ -68,7 +72,8 @@ startup
 start
 {
     // start if start variable = 1 AND if level = 1 AND if Minutes = 60 AND count is = 47120384
-    bool startGame = (current.Start == 0x1) && 
+    bool startGame = ((current.Sound == 0 && settings["sound"] == true) || (settings["sound"] == false)) &&
+                     (current.Start == 0x1) && 
                      (current.Level == 0x1) && 
                      (current.MinutesLeft == 0x3C) && 
                      (current.Count >= 0x2CE0000);

--- a/PrinceOfPersia1.4.asl
+++ b/PrinceOfPersia1.4.asl
@@ -110,10 +110,10 @@ reset
         vars.LevelSkipActivated = false;
     } else if (singleLevelModeRestart || singleLevelModeChangedLevel) {
         if ((vars.levelChanged ||
-	        (current.Level == 1 && vars.adjustedFramesLeft <= vars.levelRestartTimestamp - vars.levelRestartSafetyBuffer) ||
-	        (current.Level != 1 && vars.adjustedFramesLeft <= vars.levelRestartTimestamp) ||
-	        (vars.adjustedFramesLeft > vars.levelRestartTimestamp)) && 
-	        !(current.Level == 3 && current.Level3CP == 1)) {
+	    (current.Level == 1 && vars.adjustedFramesLeft <= vars.levelRestartTimestamp - vars.levelRestartSafetyBuffer) ||
+	    (current.Level != 1 && vars.adjustedFramesLeft <= vars.levelRestartTimestamp) ||
+	    (vars.adjustedFramesLeft > vars.levelRestartTimestamp)) && 
+	    !(current.Level == 3 && current.Level3CP == 1)) {
                 vars.levelRestartTimestamp = vars.adjustedFramesLeft;
                 vars.levelRestarted = true;
                 vars.levelChanged = false;


### PR DESCRIPTION
- Removed dependency of the timer on the category name for level skip, i.e the timer will work properly even if the category name does not contain "Level Skip", it will take `baseFramesRemaining` as 15*720 right when Shift+L is used.
- Level restart safety buffer is now restricted to level 1 only, as that is the only place where it is important.
- Reduced size of the code overall in various ways, for example by declaring the IGT calculations variable under the global "vars" class and hence avoid having to calculate in `reset{}` block again. And also by getting rid of `== true` in various boolean statements.
- The splits.io hack is now only set to be applied for full runs, and not for ILs as its not relevant for them and also avoids the very very small chance of say 23.50 being displayed as 23.49.
- Add some line break for some very lengthy if statements.