### PR TITLE
PoP: Fixed the logical error in level skip category detection

### DIFF
--- a/PrinceOfPersia1.4.asl
+++ b/PrinceOfPersia1.4.asl
@@ -138,8 +138,8 @@ gameTime
     vars.adjustedFramesLeft = (vars.minutesLeft < 0) ? 0 : vars.totalFramesLeft; //time has expired
     
     //Level skip category detection
-    if ((old.MinutesLeft != 15 && current.MinutesLeft == 15) && 
-       (old.FrameSeconds != 718 && old.FrameSeconds != 719 && current.FrameSeconds == 718) &&
+    if (!(old.MinutesLeft == 15 && (old.FrameSeconds == 718 || old.FrameSeconds == 719)) && 
+       (current.MinutesLeft == 15 && current.FrameSeconds == 718) &&
        !settings["single_level_mode"] &&
        !vars.levelSkipActivated) {
         vars.levelSkipActivated = true;


### PR DESCRIPTION
So basically, when you managed to press Shift + L on the very first frame, the level skip category detection failed due to a logical error I had made earlier.
Instead of checking if FrameSeconds is not equal 718 while also the minutes is 15, I put them as separate conditions. Due to this when someone pressed Shift + L on the first frame possible, FrameSeconds is equal to 718 and hence it didn't activate the level skip condition despite the minute being 60 rather than 15. This is my bad, sorry for not being frame perfect during testing earlier.
Resolves #4 